### PR TITLE
fix: es6 imports

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,6 @@
     "type": "git",
     "url": "https://github.com/equito-network/equito-sdk.git"
   },
-  "type": "module",
   "exports": {
     ".": {
       "require": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,6 @@
     "type": "git",
     "url": "https://github.com/equito-network/equito-sdk.git"
   },
-  "type": "module",
   "exports": {
     ".": {
       "require": {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -13,7 +13,6 @@
     "type": "git",
     "url": "https://github.com/equito-network/equito-sdk.git"
   },
-  "type": "module",
   "exports": {
     ".": {
       "require": {

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -13,7 +13,6 @@
     "type": "git",
     "url": "https://github.com/equito-network/equito-sdk.git"
   },
-  "type": "module",
   "exports": {
     ".": {
       "require": {


### PR DESCRIPTION
Add support to es6 import style, all packages default build is set to es6 instead of commonJS