### PR TITLE
feat(client): Improved `getConfirmationTime`

### DIFF
--- a/packages/client/src/client/equito-client.ts
+++ b/packages/client/src/client/equito-client.ts
@@ -170,7 +170,10 @@ export class EquitoClient {
    */
   async getBlockTimestamp(blockNumber: number): Promise<number> {
     const api = await this.getApiAt(blockNumber);
-    const timestamp = (await api.query.timestamp?.now?.())?.toHuman();
+    const timestamp = (await api.query.timestamp?.now?.())
+      ?.toHuman()
+      ?.toString()
+      .replaceAll(",", "");
     if (!timestamp) {
       throw new Error(`Timestamp not found for block ${blockNumber}`);
     }
@@ -212,7 +215,11 @@ export class EquitoClient {
     let proof: Hex | undefined;
     let checkedBlocks = 0;
     do {
-      proof = await this.getProof(messageHash, chainSelector, blockNumber);
+      proof = await this.getProof(
+        messageHash,
+        chainSelector,
+        blockNumber + checkedBlocks
+      );
       checkedBlocks++;
     } while (!proof && checkedBlocks < listenTimeout);
 

--- a/packages/client/src/client/equito-client.ts
+++ b/packages/client/src/client/equito-client.ts
@@ -127,11 +127,11 @@ export class EquitoClient {
     blockNumber?: number
   ): Promise<Hex[]> {
     const api = await this.getApiAt(blockNumber);
-    const signatures = await api.query.equitoEvm?.signatures?.entries<Hex>(
+    const signatures = await api.query.equitoEvm?.signatures?.entries(
       messageHash
     );
 
-    return signatures?.map(([, signature]) => signature) || [];
+    return signatures?.map(([, signature]) => signature.toHex()) || [];
   }
 
   /**

--- a/packages/client/src/client/equito-client.ts
+++ b/packages/client/src/client/equito-client.ts
@@ -213,17 +213,13 @@ export class EquitoClient {
     }
 
     let proof: Hex | undefined;
-    let checkedBlocks = 0;
+    const blockNumberLimit = blockNumber + listenTimeout;
     do {
-      proof = await this.getProof(
-        messageHash,
-        chainSelector,
-        blockNumber + checkedBlocks
-      );
-      checkedBlocks++;
-    } while (!proof && checkedBlocks < listenTimeout);
+      proof = await this.getProof(messageHash, chainSelector, blockNumber);
+      blockNumber++;
+    } while (!proof && blockNumber < blockNumberLimit);
 
-    if (checkedBlocks >= listenTimeout || !proof) {
+    if (blockNumber >= blockNumberLimit || !proof) {
       throw new Error(
         `No proof found for message ${messageHash} from timestamp ${fromTimestamp} in the last ${listenTimeout} blocks`
       );

--- a/packages/client/src/client/equito-client.types.ts
+++ b/packages/client/src/client/equito-client.types.ts
@@ -91,3 +91,17 @@ export type GetConfirmationTimeArgs = {
    */
   listenTimeout?: number;
 };
+
+/**
+ * The return type of the getConfirmationTime function.
+ */
+export type GetConfirmationTimeReturnType = {
+  /**
+   * The timestamp in milliseconds of the confirmation.
+   */
+  timestamp: number;
+  /**
+   * The message proof in {@link Hex} format.
+   */
+  proof: Hex;
+};

--- a/packages/viem/src/router/get-fee.ts
+++ b/packages/viem/src/router/get-fee.ts
@@ -4,7 +4,7 @@ import { Hex, PublicClient } from "viem";
 /**
  * The arguments for the getFee function.
  */
-type GetFeeArgs = {
+export type GetFeeArgs = {
   /**
    * The {@link PublicClient} that will be used to read the contract.
    */


### PR DESCRIPTION
Improve getConfirmationTime in order to get proof and timestamp of the confirmed message