### PR TITLE
feat(core): add supported chains and utility methods

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,8 +40,5 @@
   "files": [
     "dist",
     "README.md"
-  ],
-  "dependencies": {
-    "dotenv": "^16.4.5"
-  }
+  ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "prepack": "pnpm build"
   },
   "devDependencies": {
+    "@types/node": "^22.2.0",
     "tsup": "^8.1.0",
     "typedoc": "^0.26.3",
     "typescript": "^5.5.2"
@@ -39,5 +40,8 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "dependencies": {
+    "dotenv": "^16.4.5"
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export * from "./supported-chains";

--- a/packages/core/src/supported-chains/chain-selectors.json
+++ b/packages/core/src/supported-chains/chain-selectors.json
@@ -1,0 +1,207 @@
+{
+  "1": {
+    "names": ["ethereum", "eth"],
+    "image": "images/ethereum.svg"
+  },
+  "2": {
+    "names": ["bsc", "bnb"],
+    "image": "images/bsc.svg"
+  },
+  "3": {
+    "names": ["polygon"],
+    "image": "images/polygon.svg"
+  },
+  "4": {
+    "names": ["arbitrum"],
+    "image": "images/arbitrum.svg"
+  },
+  "5": {
+    "names": ["avalanche", "avalance c-chain"],
+    "image": "images/avalanche.svg"
+  },
+  "6": {
+    "names": ["optimism", "op"],
+    "image": "images/optimism.svg"
+  },
+  "7": {
+    "names": ["base"],
+    "image": "images/base.svg"
+  },
+  "8": {
+    "names": ["fantom"],
+    "image": "images/fantom.svg"
+  },
+  "9": {
+    "names": ["celo"],
+    "image": "images/celo.svg"
+  },
+  "10": {
+    "names": ["telos"],
+    "image": "images/telos.svg"
+  },
+  "11": {
+    "names": ["arthera"],
+    "image": "images/arthera.svg"
+  },
+  "12": {
+    "names": ["rollux"],
+    "image": "images/rollux.svg"
+  },
+  "13": {
+    "names": ["skale"],
+    "image": "images/skale.svg"
+  },
+  "14": {
+    "names": ["linea"],
+    "image": "images/linea.svg"
+  },
+  "15": {
+    "names": ["oasis emerald"],
+    "image": "images/oasis_emerald.svg"
+  },
+  "16": {
+    "names": ["merlin"],
+    "image": "images/merlin.svg"
+  },
+  "17": {
+    "names": ["sei evm"],
+    "image": "images/sei_evm.svg"
+  },
+  "18": {
+    "names": ["blast"],
+    "image": "images/blast.svg"
+  },
+  "19": {
+    "names": ["gnosis"],
+    "image": "images/gnosis.svg"
+  },
+  "20": {
+    "names": ["scroll"],
+    "image": "images/scroll.svg"
+  },
+  "21": {
+    "names": ["mantle"],
+    "image": "images/mantle.svg"
+  },
+  "22": {
+    "names": ["opbnb"],
+    "image": "images/opbnb.svg"
+  },
+  "23": {
+    "names": ["zk-sync", "zk-sync era", "zksync", "zksync era"],
+    "image": "images/zksync.svg"
+  },
+  "24": {
+    "names": ["xdc"],
+    "image": "images/xdc.svg"
+  },
+  "25": {
+    "names": ["ten"],
+    "image": "images/ten.svg"
+  },
+  "1001": {
+    "names": ["sepolia", "ethereum sepolia", "eth sepolia"],
+    "image": "images/sepolia.svg"
+  },
+  "1002": {
+    "names": ["bsc testnet", "bnb testnet"],
+    "image": "images/bsc-testnet.svg"
+  },
+  "1003": {
+    "names": ["polygon testnet", "polygon amoy"],
+    "image": "images/polygon-testnet.svg"
+  },
+  "1004": {
+    "names": ["arbitrum sepolia"],
+    "image": "images/arbitrum-sepolia.svg"
+  },
+  "1005": {
+    "names": ["avalanche testnet", "avalanche fuji"],
+    "image": "images/avalanche-testnet.svg"
+  },
+  "1006": {
+    "names": ["optimism sepolia", "op sepolia"],
+    "image": "images/optimism-sepolia.svg"
+  },
+  "1007": {
+    "names": ["base sepolia"],
+    "image": "images/base-sepolia.svg"
+  },
+  "1008": {
+    "names": ["fantom testnet"],
+    "image": "images/fantom-testnet.svg"
+  },
+  "1009": {
+    "names": ["celo testnet", "celo alfajores"],
+    "image": "images/celo-testnet.svg"
+  },
+  "1010": {
+    "names": ["telos testnet"],
+    "image": "images/telos-testnet.svg"
+  },
+  "1011": {
+    "names": ["arthera testnet"],
+    "image": "images/arthera-testnet.svg"
+  },
+  "1012": {
+    "names": ["rollux testnet", "rollux tanenbaum"],
+    "image": "images/rollux-testnet.svg"
+  },
+  "1013": {
+    "names": ["skale calypso testnet"],
+    "image": "images/skale-calypso-testnet.svg"
+  },
+  "1014": {
+    "names": ["linea sepolia"],
+    "image": "images/linea-sepolia.svg"
+  },
+  "1015": {
+    "names": ["oasis emerald testnet"],
+    "image": "images/oasis-emerald-testnet.svg"
+  },
+  "1016": {
+    "names": ["merlin testnet"],
+    "image": "images/merlin-testnet.svg"
+  },
+  "1017": {
+    "names": ["sei evm atlantic", "sei evm testnet"],
+    "image": "images/sei-evm-atlantic.svg"
+  },
+  "1018": {
+    "names": ["blast sepolia"],
+    "image": "images/blast-sepolia.svg"
+  },
+  "1019": {
+    "names": ["gnosis chiado", "gnosis testnet"],
+    "image": "images/gnosis_chiado.svg"
+  },
+  "1020": {
+    "names": ["scroll sepolia"],
+    "image": "images/scroll_sepolia.svg"
+  },
+  "1021": {
+    "names": ["mantle sepolia"],
+    "image": "images/mantle_sepolia.svg"
+  },
+  "1022": {
+    "names": ["opbnb testnet"],
+    "image": "images/opbnb_testnet.svg"
+  },
+  "1023": {
+    "names": [
+      "zk-sync sepolia",
+      "zk-sync era sepolia",
+      "zksync sepolia",
+      "zksync era sepolia"
+    ],
+    "image": "images/zksync_sepolia.svg"
+  },
+  "1024": {
+    "names": ["xdc testnet", "xdc apothem"],
+    "image": "images/xdc_testnet.svg"
+  },
+  "1025": {
+    "names": ["ten testnet"],
+    "image": "images/ten_testnet.svg"
+  }
+}

--- a/packages/core/src/supported-chains/chain-selectors.json
+++ b/packages/core/src/supported-chains/chain-selectors.json
@@ -1,191 +1,144 @@
 {
   "1": {
-    "names": ["ethereum", "eth"],
-    "image": "images/ethereum.svg"
+    "names": ["ethereum", "eth"]
   },
   "2": {
-    "names": ["bsc", "bnb"],
-    "image": "images/bsc.svg"
+    "names": ["bsc", "bnb"]
   },
   "3": {
-    "names": ["polygon"],
-    "image": "images/polygon.svg"
+    "names": ["polygon"]
   },
   "4": {
-    "names": ["arbitrum"],
-    "image": "images/arbitrum.svg"
+    "names": ["arbitrum"]
   },
   "5": {
-    "names": ["avalanche", "avalance c-chain"],
-    "image": "images/avalanche.svg"
+    "names": ["avalanche", "avalance c-chain"]
   },
   "6": {
-    "names": ["optimism", "op"],
-    "image": "images/optimism.svg"
+    "names": ["optimism", "op"]
   },
   "7": {
-    "names": ["base"],
-    "image": "images/base.svg"
+    "names": ["base"]
   },
   "8": {
-    "names": ["fantom"],
-    "image": "images/fantom.svg"
+    "names": ["fantom"]
   },
   "9": {
-    "names": ["celo"],
-    "image": "images/celo.svg"
+    "names": ["celo"]
   },
   "10": {
-    "names": ["telos"],
-    "image": "images/telos.svg"
+    "names": ["telos"]
   },
   "11": {
-    "names": ["arthera"],
-    "image": "images/arthera.svg"
+    "names": ["arthera"]
   },
   "12": {
-    "names": ["rollux"],
-    "image": "images/rollux.svg"
+    "names": ["rollux"]
   },
   "13": {
-    "names": ["skale"],
-    "image": "images/skale.svg"
+    "names": ["skale"]
   },
   "14": {
-    "names": ["linea"],
-    "image": "images/linea.svg"
+    "names": ["linea"]
   },
   "15": {
-    "names": ["oasis emerald"],
-    "image": "images/oasis_emerald.svg"
+    "names": ["oasis emerald"]
   },
   "16": {
-    "names": ["merlin"],
-    "image": "images/merlin.svg"
+    "names": ["merlin"]
   },
   "17": {
-    "names": ["sei evm"],
-    "image": "images/sei_evm.svg"
+    "names": ["sei evm"]
   },
   "18": {
-    "names": ["blast"],
-    "image": "images/blast.svg"
+    "names": ["blast"]
   },
   "19": {
-    "names": ["gnosis"],
-    "image": "images/gnosis.svg"
+    "names": ["gnosis"]
   },
   "20": {
-    "names": ["scroll"],
-    "image": "images/scroll.svg"
+    "names": ["scroll"]
   },
   "21": {
-    "names": ["mantle"],
-    "image": "images/mantle.svg"
+    "names": ["mantle"]
   },
   "22": {
-    "names": ["opbnb"],
-    "image": "images/opbnb.svg"
+    "names": ["opbnb"]
   },
   "23": {
-    "names": ["zk-sync", "zk-sync era", "zksync", "zksync era"],
-    "image": "images/zksync.svg"
+    "names": ["zk-sync", "zk-sync era", "zksync", "zksync era"]
   },
   "24": {
-    "names": ["xdc"],
-    "image": "images/xdc.svg"
+    "names": ["xdc"]
   },
   "25": {
-    "names": ["ten"],
-    "image": "images/ten.svg"
+    "names": ["ten"]
   },
   "1001": {
-    "names": ["sepolia", "ethereum sepolia", "eth sepolia"],
-    "image": "images/sepolia.svg"
+    "names": ["sepolia", "ethereum sepolia", "eth sepolia"]
   },
   "1002": {
-    "names": ["bsc testnet", "bnb testnet"],
-    "image": "images/bsc-testnet.svg"
+    "names": ["bsc testnet", "bnb testnet"]
   },
   "1003": {
-    "names": ["polygon testnet", "polygon amoy"],
-    "image": "images/polygon-testnet.svg"
+    "names": ["polygon testnet", "polygon amoy"]
   },
   "1004": {
-    "names": ["arbitrum sepolia"],
-    "image": "images/arbitrum-sepolia.svg"
+    "names": ["arbitrum sepolia"]
   },
   "1005": {
-    "names": ["avalanche testnet", "avalanche fuji"],
-    "image": "images/avalanche-testnet.svg"
+    "names": ["avalanche testnet", "avalanche fuji"]
   },
   "1006": {
-    "names": ["optimism sepolia", "op sepolia"],
-    "image": "images/optimism-sepolia.svg"
+    "names": ["optimism sepolia", "op sepolia"]
   },
   "1007": {
-    "names": ["base sepolia"],
-    "image": "images/base-sepolia.svg"
+    "names": ["base sepolia"]
   },
   "1008": {
-    "names": ["fantom testnet"],
-    "image": "images/fantom-testnet.svg"
+    "names": ["fantom testnet"]
   },
   "1009": {
-    "names": ["celo testnet", "celo alfajores"],
-    "image": "images/celo-testnet.svg"
+    "names": ["celo testnet", "celo alfajores"]
   },
   "1010": {
-    "names": ["telos testnet"],
-    "image": "images/telos-testnet.svg"
+    "names": ["telos testnet"]
   },
   "1011": {
-    "names": ["arthera testnet"],
-    "image": "images/arthera-testnet.svg"
+    "names": ["arthera testnet"]
   },
   "1012": {
-    "names": ["rollux testnet", "rollux tanenbaum"],
-    "image": "images/rollux-testnet.svg"
+    "names": ["rollux testnet", "rollux tanenbaum"]
   },
   "1013": {
-    "names": ["skale calypso testnet"],
-    "image": "images/skale-calypso-testnet.svg"
+    "names": ["skale calypso testnet"]
   },
   "1014": {
-    "names": ["linea sepolia"],
-    "image": "images/linea-sepolia.svg"
+    "names": ["linea sepolia"]
   },
   "1015": {
-    "names": ["oasis emerald testnet"],
-    "image": "images/oasis-emerald-testnet.svg"
+    "names": ["oasis emerald testnet"]
   },
   "1016": {
-    "names": ["merlin testnet"],
-    "image": "images/merlin-testnet.svg"
+    "names": ["merlin testnet"]
   },
   "1017": {
-    "names": ["sei evm atlantic", "sei evm testnet"],
-    "image": "images/sei-evm-atlantic.svg"
+    "names": ["sei evm atlantic", "sei evm testnet"]
   },
   "1018": {
-    "names": ["blast sepolia"],
-    "image": "images/blast-sepolia.svg"
+    "names": ["blast sepolia"]
   },
   "1019": {
-    "names": ["gnosis chiado", "gnosis testnet"],
-    "image": "images/gnosis_chiado.svg"
+    "names": ["gnosis chiado", "gnosis testnet"]
   },
   "1020": {
-    "names": ["scroll sepolia"],
-    "image": "images/scroll_sepolia.svg"
+    "names": ["scroll sepolia"]
   },
   "1021": {
-    "names": ["mantle sepolia"],
-    "image": "images/mantle_sepolia.svg"
+    "names": ["mantle sepolia"]
   },
   "1022": {
-    "names": ["opbnb testnet"],
-    "image": "images/opbnb_testnet.svg"
+    "names": ["opbnb testnet"]
   },
   "1023": {
     "names": [
@@ -193,15 +146,12 @@
       "zk-sync era sepolia",
       "zksync sepolia",
       "zksync era sepolia"
-    ],
-    "image": "images/zksync_sepolia.svg"
+    ]
   },
   "1024": {
-    "names": ["xdc testnet", "xdc apothem"],
-    "image": "images/xdc_testnet.svg"
+    "names": ["xdc testnet", "xdc apothem"]
   },
   "1025": {
-    "names": ["ten testnet"],
-    "image": "images/ten_testnet.svg"
+    "names": ["ten testnet"]
   }
 }

--- a/packages/core/src/supported-chains/index.ts
+++ b/packages/core/src/supported-chains/index.ts
@@ -4,7 +4,7 @@ import { EquitoChain } from "../types";
 // Assert correct type for chain-selectors.json file
 const chainSelectors = chainSelectorsJson as Record<
     string,
-    { names: string[]; image: string }
+    { names: string[]; }
 >;
 /**
  * @title getChainSelectorByName
@@ -48,11 +48,10 @@ export function getChainSelectorByName(name: string): number {
  */
 export function getAllSupportedChains(): EquitoChain[] {
     const supportedChains = [];
-    for (const [selector, { names, image }] of Object.entries(chainSelectors)) {
+    for (const [selector, { names }] of Object.entries(chainSelectors)) {
         supportedChains.push({
             chainSelector: Number(selector),
             names,
-            image,
         });
     }
     return supportedChains;

--- a/packages/core/src/supported-chains/index.ts
+++ b/packages/core/src/supported-chains/index.ts
@@ -1,0 +1,86 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+// Load environment variables from .env file
+dotenv.config({ path: path.join(__dirname, "../.env") });
+
+// Path to the chain-selectors.json file
+const chainSelectorsPath = path.join(__dirname, "chain-selectors.json");
+
+// Read and parse the chain-selectors.json file
+const chainSelectors = JSON.parse(
+    fs.readFileSync(chainSelectorsPath, "utf-8")
+) as Record<string, { names: string[]; image: string }>;
+
+/**
+ * @title getChainSelectorByName
+ * @description Returns the chain selector value for a given chain name.
+ * @param {string} name - The name of the chain to look up.
+ * @returns {number} - The chain selector associated with the given chain name.
+ * @throws {Error} - Throws an error if the provided chain name is not supported.
+ * 
+ * @example
+ * const selector = getChainSelectorByName("ethereum");
+ * console.log(selector); // Outputs: 1
+ */
+export function getChainSelectorByName(name: string): number {
+    const lowerCaseName = name.toLowerCase();
+
+    for (const [selector, { names }] of Object.entries(chainSelectors)) {
+        if (names.includes(lowerCaseName)) {
+            return Number(selector);
+        }
+    }
+
+    throw new Error(`Invalid or unsupported Chain Name: ${name}`);
+}
+
+/**
+ * @title getAllSupportedChains
+ * @description Retrieves all supported chains with their respective chain selector, name, and image path.
+ * 
+ * @returns {Array<{ chainSelector: number, name: string, image: string }>}
+ * - An array of objects, each containing the chain selector, name, and image path for a supported chain.
+ * 
+ * @example
+ * const chains = getAllSupportedChains();
+ * console.log(chains);
+ * // [
+ * //   { chainSelector: 0, name: "equito", image: "images/equito.svg" },
+ * //   { chainSelector: 1, name: "ethereum", image: "images/ethereum.svg" },
+ * //   ...
+ * // ]
+ */
+export function getAllSupportedChains(): Array<{ chainSelector: number, name: string, image: string }> {
+    const supportedChains = [];
+
+    for (const [selector, { names, image }] of Object.entries(chainSelectors)) {
+        if (names[0]) {
+            supportedChains.push({
+                chainSelector: Number(selector),
+                name: names[0],
+                image,
+            });
+        }
+    }
+
+    return supportedChains;
+}
+
+/**
+ * @description Get the primary name of the chain by its selector.
+ * @param {number} chainSelector - The selector value for the chain.
+ * @returns {string} - The primary name of the chain.
+ * @throws {Error} - Throws an error if the chain selector is not found.
+ */
+export function getNameByChainSelector(chainSelector: number): string | undefined {
+    const chainData = chainSelectors[chainSelector];
+
+    if (!chainData || chainData.names.length === 0) {
+        throw new Error(`Invalid or unsupported Chain Selector: ${chainSelector}`);
+    }
+
+    // Assuming the first name in the list is the primary name
+    return chainData.names[0];
+}

--- a/packages/core/src/supported-chains/index.ts
+++ b/packages/core/src/supported-chains/index.ts
@@ -1,18 +1,10 @@
-import * as fs from "fs";
-import * as path from "path";
-import * as dotenv from "dotenv";
+import chainSelectorsJson from "./chain-selectors.json";
 
-// Load environment variables from .env file
-dotenv.config({ path: path.join(__dirname, "../.env") });
-
-// Path to the chain-selectors.json file
-const chainSelectorsPath = path.join(__dirname, "chain-selectors.json");
-
-// Read and parse the chain-selectors.json file
-const chainSelectors = JSON.parse(
-    fs.readFileSync(chainSelectorsPath, "utf-8")
-) as Record<string, { names: string[]; image: string }>;
-
+// Assert correct type for chain-selectors.json file
+const chainSelectors = chainSelectorsJson as Record<
+  string,
+  { names: string[]; image: string }
+>;
 /**
  * @title getChainSelectorByName
  * @description Returns the chain selector value for a given chain name.
@@ -74,7 +66,7 @@ export function getAllSupportedChains(): Array<{ chainSelector: number, name: st
  * @returns {string} - The primary name of the chain.
  * @throws {Error} - Throws an error if the chain selector is not found.
  */
-export function getNameByChainSelector(chainSelector: number): string | undefined {
+export function getNameByChainSelector(chainSelector: number): string {
     const chainData = chainSelectors[chainSelector];
 
     if (!chainData || chainData.names.length === 0) {

--- a/packages/core/src/supported-chains/index.ts
+++ b/packages/core/src/supported-chains/index.ts
@@ -1,9 +1,10 @@
 import chainSelectorsJson from "./chain-selectors.json";
+import { EquitoChain } from "../types";
 
 // Assert correct type for chain-selectors.json file
 const chainSelectors = chainSelectorsJson as Record<
-  string,
-  { names: string[]; image: string }
+    string,
+    { names: string[]; image: string }
 >;
 /**
  * @title getChainSelectorByName
@@ -28,51 +29,47 @@ export function getChainSelectorByName(name: string): number {
     throw new Error(`Invalid or unsupported Chain Name: ${name}`);
 }
 
+
 /**
  * @title getAllSupportedChains
  * @description Retrieves all supported chains with their respective chain selector, name, and image path.
  * 
- * @returns {Array<{ chainSelector: number, name: string, image: string }>}
- * - An array of objects, each containing the chain selector, name, and image path for a supported chain.
+ * @returns {EquitoChain []}
+ * - An array of objects, each containing the chain selector, names, and image path for a supported chain.
  * 
  * @example
  * const chains = getAllSupportedChains();
  * console.log(chains);
  * // [
- * //   { chainSelector: 0, name: "equito", image: "images/equito.svg" },
- * //   { chainSelector: 1, name: "ethereum", image: "images/ethereum.svg" },
+ * //   { chainSelector: 1, names: ["ethereum", "eth"], image: "images/ethereum.svg" },
+ * //   { chainSelector: 2, names: ["bsc", "bnb"], image: "images/bsc.svg" },
  * //   ...
  * // ]
  */
-export function getAllSupportedChains(): Array<{ chainSelector: number, name: string, image: string }> {
+export function getAllSupportedChains(): EquitoChain[] {
     const supportedChains = [];
-
     for (const [selector, { names, image }] of Object.entries(chainSelectors)) {
-        if (names[0]) {
-            supportedChains.push({
-                chainSelector: Number(selector),
-                name: names[0],
-                image,
-            });
-        }
+        supportedChains.push({
+            chainSelector: Number(selector),
+            names,
+            image,
+        });
     }
-
     return supportedChains;
 }
 
 /**
- * @description Get the primary name of the chain by its selector.
+ * @description Retrieves the chain information, including names or aliases and image, associated with a specific chain selector.
  * @param {number} chainSelector - The selector value for the chain.
- * @returns {string} - The primary name of the chain.
- * @throws {Error} - Throws an error if the chain selector is not found.
+ * @returns {EquitoChain} - An object containing the chain selector, names, and image associated with the chain.
+ * @throws {Error} - Throws an error if the chain selector is invalid or not found.
  */
-export function getNameByChainSelector(chainSelector: number): string {
+export function getByChainSelector(chainSelector: number): EquitoChain {
     const chainData = chainSelectors[chainSelector];
 
-    if (!chainData || chainData.names.length === 0) {
-        throw new Error(`Invalid or unsupported Chain Selector: ${chainSelector}`);
+    if (chainData) {
+        return { chainSelector, ...chainData };
     }
 
-    // Assuming the first name in the list is the primary name
-    return chainData.names[0];
+    throw new Error(`Invalid or unsupported Chain Selector: ${chainSelector}`);
 }

--- a/packages/core/src/types/misc.ts
+++ b/packages/core/src/types/misc.ts
@@ -1,1 +1,21 @@
 export type Hex = `0x${string}`;
+
+/**
+ * @interface EquitoChain
+ * @description Represents a blockchain configuration used within the Equito ecosystem.
+ * 
+ * @property {number} chainSelector - A unique numeric identifier for the blockchain. 
+ * Typically used to differentiate between different blockchains or network configurations.
+ * 
+ * @property {string[]} names - An array of strings representing different names or aliases 
+ * for the blockchain. This can include common names, abbreviations, or other recognized identifiers.
+ * 
+ * @property {string} image - A string representing the path to an image (e.g., an SVG or PNG file)
+ * that visually represents the blockchain. This could be a logo or any other relevant image.
+ */
+export interface EquitoChain {
+    chainSelector: number;
+    names: string[];
+    image: string;
+}
+

--- a/packages/core/src/types/misc.ts
+++ b/packages/core/src/types/misc.ts
@@ -9,13 +9,9 @@ export type Hex = `0x${string}`;
  * 
  * @property {string[]} names - An array of strings representing different names or aliases 
  * for the blockchain. This can include common names, abbreviations, or other recognized identifiers.
- * 
- * @property {string} image - A string representing the path to an image (e.g., an SVG or PNG file)
- * that visually represents the blockchain. This could be a logo or any other relevant image.
  */
 export interface EquitoChain {
     chainSelector: number;
     names: string[];
-    image: string;
 }
 


### PR DESCRIPTION
## Add `chain-selectors.json` and utility methods 

This PR introduces the `chain-selectors.json` file, which stores mappings between chain selectors and their corresponding names and images. The following utility methods have been added:

- `getChainSelectorByName(name: string): number`: Retrieves the chain selector for a given chain name.
- `getAllSupportedChains(): Array<{ chainSelector: number, name: string, image: string }>`: Returns a list of all supported -chains with their chain selector, name, and image.
- `getNameByChainSelector(chainSelector: number): string`: Retrieves the name of the chain associated with the given chain selector. This returns the first name stored

fixes: #16 